### PR TITLE
Refactor to use Cuttlefish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "manta-sync": "./manta-sync.js"
   },
   "dependencies": {
-    "posix-getopt": "~1.0.0",
     "findit": "~1.1.0",
     "latest": "~0.1.2",
     "async": "~0.2.9",
     "manta": "~1.2.2",
-    "cuttlefish": "~1.2.0"
+    "cuttlefish": "~1.2.0",
+    "dashdash": "git://github.com/isaacs/node-dashdash",
+    "manta-client": "~1.0.4"
   }
 }


### PR DESCRIPTION
The logging output is all completely changed, since Cuttlefish does things in a single big task queue, rather than a bunch of independent steps.

But, I'm seeing about a 10-20% speed increase, once I figured out how to work around joyent/node-manta#152.

If it meets with your approval, you can probably nudge the logging output around easily enough using the events that Cuttlefish gives you.  I'd also recommend adding a flag to enable the `timingDebug` option in Cuttlefish, it's really useful for debugging issues.
