### PR TITLE
Changing basefile to use path-platform's split.

### DIFF
--- a/manta-sync
+++ b/manta-sync
@@ -227,7 +227,7 @@ finder.on('file', function(file, stat) {
   var d = {
     file: file,
     stat: stat,
-    basefile: file.substr(localdir.length)
+    basefile: path.splitPath(file)[2]
   };
   d.mantafile = path.posix.join(remotedir, d.basefile);
 


### PR DESCRIPTION
Currently manta-sync will file.substr(localdir.length) leaving a basefile like `'\foo.txt'`, then later when you have the posix join you get a path like `'/mantauser/stor/\foo.txt'`

This change chops off the leading `/ or \` 
