### PR TITLE
Bump dependencies for Node.js v4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,16 +13,16 @@
     "test": "for f in lib/*.js; do node \"$f\" || exit 1; done; echo Passed"
   },
   "dependencies": {
-    "bunyan": "~1.3.4",
+    "bunyan": "~1.5",
     "dashdash": "~1.7.3",
     "humanize-time": "0.0.2",
     "latest": "~0.2.0",
-    "manta": "^2.0.7",
+    "manta": "~3.0.0",
     "mkdirp": "^0.5.0",
     "once": "^1.3.1",
     "path-platform": "0.0.1",
     "pretty-bytes": "^1.0.3",
-    "restify": "~2.8.5",
+    "restify": "~4.0.0",
     "strsplit": "~1.0.0",
     "vasync": "~1.6.2"
   }


### PR DESCRIPTION
This bumps the versions of bunyan, manta and restify such that each gets  recent version of dtrace-provider (typically 0.6.0 I think) which works with Node.js v4. 

I ran `npm test` and everything passes and I also ran a sync of my ~/Downloads dir which had a good mix of files of various sizes to  ~~/stor/mata-sync-test and didn't hit any issues.

I didn't change the package version though since I'm never quite sure what makes sense for this type of change (`"version": "0.4.0"` ?). Each dependency was updated to a newer major version which in theory could be breaking in some way.